### PR TITLE
Modified your code to not recreate NSDateFormatter each iteration

### DIFF
--- a/NSDateISO8601.swift
+++ b/NSDateISO8601.swift
@@ -7,22 +7,33 @@
 
 import Foundation
 
-public extension NSDate {
-    public class func ISOStringFromDate(date: NSDate) -> String {
+private struct ISONSDateFormatters {
+    
+    static let ISOStringFromDateFormatter: NSDateFormatter = {
         var dateFormatter = NSDateFormatter()
         dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         dateFormatter.timeZone = NSTimeZone(abbreviation: "GMT")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-        
-        return dateFormatter.stringFromDate(date).stringByAppendingString("Z")
-    }
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        return dateFormatter
+        }()
     
-    public class func dateFromISOString(string: String) -> NSDate {
+    static let dateFromISOStringFormatter: NSDateFormatter = {
         var dateFormatter = NSDateFormatter()
         dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         dateFormatter.timeZone = NSTimeZone.localTimeZone()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        
-        return dateFormatter.dateFromString(string)
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return dateFormatter
+        }()
+    
+}
+
+extension NSDate {
+    
+    class func ISOStringFromDate(date: NSDate) -> String {
+        return ISONSDateFormatters.ISOStringFromDateFormatter.stringFromDate(date).stringByAppendingString("Z")
+    }
+    
+    class func dateFromISOString(string: String) -> NSDate? {
+        return ISONSDateFormatters.dateFromISOStringFormatter.dateFromString(string)
     }
 }


### PR DESCRIPTION
Hey, I modified your code to not recreate the NSDateFormatter. In a 2000 iteration test on the dateFromISOStringFormatter method I went from 5.414452016353607 seconds to 3.420518040657043 seconds. Feel free to improve upon further.
